### PR TITLE
Use count(:all) to fix issue of Geocoder with Rails 4.1

### DIFF
--- a/lib/active_model/pagination_serializer.rb
+++ b/lib/active_model/pagination_serializer.rb
@@ -4,7 +4,7 @@ class ActiveModel::PaginationSerializer < ActiveModel::ArraySerializer
     per_page = object.limit_value
     offset = object.offset_value
     current_page = offset ? (offset / per_page) + 1 : 1
-    total_items = object.limit(nil).offset(nil).count
+    total_items = object.limit(nil).offset(nil).count(:all)
     total_pages = per_page ? (total_items / per_page.to_f).ceil : 1
     prev_page = current_page - 1
     prev_page = nil if prev_page < 1


### PR DESCRIPTION
www.pivotaltracker.com/story/show/107064082

Due to the update to Rails 4.1, Geocoder has a issue with regards
to its SQL composition. This causes a syntax error to Geocoder's
Location-based queries.

Issue can be found here:
https://github.com/alexreisner/geocoder/issues/630
