### PR TITLE
Prepare 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.2
+
+- Use count(:all) to fix issue of Geocoder with Rails 4.1
+
 # 0.1.1
 
 - Fix bug where page count was incorrect

--- a/lib/active_model_serializers_contrib/version.rb
+++ b/lib/active_model_serializers_contrib/version.rb
@@ -1,3 +1,3 @@
 module ActiveModelSerializersContrib
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
Bump to version 0.1.2

We don't have publish rights for this gem.
