### PR TITLE
Handle grouped relations

### DIFF
--- a/lib/active_model/pagination_serializer.rb
+++ b/lib/active_model/pagination_serializer.rb
@@ -4,7 +4,7 @@ class ActiveModel::PaginationSerializer < ActiveModel::ArraySerializer
     per_page = object.limit_value
     offset = object.offset_value
     current_page = offset ? (offset / per_page) + 1 : 1
-    total_items = object.limit(nil).offset(nil).count(:all)
+    total_items = item_count(object)
     total_pages = per_page ? (total_items / per_page.to_f).ceil : 1
     prev_page = current_page - 1
     prev_page = nil if prev_page < 1
@@ -23,5 +23,13 @@ class ActiveModel::PaginationSerializer < ActiveModel::ArraySerializer
   end
 
   alias_method_chain :initialize, :pagination
+
+  private
+
+  def item_count(object)
+    initial_count = object.limit(nil).offset(nil).count(:all)
+
+    (initial_count.respond_to? :count) ? initial_count.count : initial_count
+  end
 
 end

--- a/spec/dummy/app/controllers/books_controller.rb
+++ b/spec/dummy/app/controllers/books_controller.rb
@@ -18,4 +18,10 @@ class BooksController < ApplicationController
     respond_with books, serializer: ActiveModel::PaginationSerializer
   end
 
+  def grouped
+    books = Book.page(params[:page]).per(params[:per_page]).group(:id)
+
+    respond_with books, serializer: ActiveModel::PaginationSerializer
+  end
+
 end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
     collection do
       get 'no_pagination'
       get 'multiple_fields_to_count'
+      get 'grouped'
     end
   end
   # The priority is based upon order of creation: first created -> highest priority.

--- a/spec/requests/pagination_serializer_spec.rb
+++ b/spec/requests/pagination_serializer_spec.rb
@@ -71,6 +71,20 @@ RSpec.describe "PaginationSerializer", type: :request do
         expect(meta[:next_page]).to eq nil
       end
     end
+
+    context "relation is grouped" do
+      it "does not blow up" do
+        get "/books/grouped", page: 10, per_page: 2, format: :json
+        hash = JSON.parse(response.body).with_indifferent_access
+        meta = hash[:meta]
+        expect(meta[:current_page]).to eq 10
+        expect(meta[:total_pages]).to eq 10
+        expect(meta[:total_items]).to eq 20
+        expect(meta[:prev_page]).to eq 9
+        expect(meta[:next_page]).to eq nil
+        expect(meta[:per_page]).to eq 2
+      end
+    end
   end
 
   context "there are no books" do


### PR DESCRIPTION
When grouped relation is passed to PaginationSerializer the following code may blow up:

```
total_items = object.limit(nil).offset(nil).count(:all)
total_pages = per_page ? (total_items / per_page.to_f).ceil : 1
```

because total_items is a Hash, not a number.

From ActiveRecord::Calculations.count docs:

> If count is used with Relation#group, it returns a Hash whose keys represent the aggregated column, and the values are the respective amounts.

We are interested in the Hash count, as this indicates the number of groups.
