### PR TITLE
[#155929975] Rails 5 upgrade - Remove #alias_method_chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# [TBA]
+
+- Make gem Rails 5 compatible.
+- Remove #alias_method_chain
+
 # 0.2.1
 
 - Fix bug where a passing a grouped relation to PaginationSerializer results in an error

--- a/lib/active_model/pagination_serializer.rb
+++ b/lib/active_model/pagination_serializer.rb
@@ -22,7 +22,8 @@ class ActiveModel::PaginationSerializer < ActiveModel::ArraySerializer
     initialize_without_pagination(object, opts)
   end
 
-  alias_method_chain :initialize, :pagination
+  alias_method :initialize_without_pagination, :initialize
+  alias_method :initialize, :initialize_with_pagination
 
   private
 

--- a/lib/active_model_serializers_contrib/version.rb
+++ b/lib/active_model_serializers_contrib/version.rb
@@ -1,3 +1,3 @@
 module ActiveModelSerializersContrib
-  VERSION = "0.2.1"
+  VERSION = "0.3.0.alpha"
 end


### PR DESCRIPTION
- `#alias_method_chain` has been deprecated in Rails 5
  Reference: https://github.com/rails/rails/pull/19434